### PR TITLE
tests: Don't rely on values that vary from backend to backend

### DIFF
--- a/tests/HanAssist.localize.test.ts
+++ b/tests/HanAssist.localize.test.ts
@@ -106,17 +106,9 @@ describe('HanAssist.localize', () => {
       sg: BigInt(123),
     };
 
-    test.each([
-      { locale: 'zh', expected: '123' },
-      { locale: 'zh-hans', expected: 'Symbol()' },
-      { locale: 'zh-hant', expected: 'function () { }' },
-      { locale: 'zh-cn', expected: '123' },
-      { locale: 'zh-sg', expected: '123' },
-      { locale: 'zh-my', expected: 'true' },
-      { locale: 'zh-mo', expected: '[object Object]' },
-      { locale: 'zh-hk', expected: 'function Function() { [native code] }' },
-      { locale: 'zh-tw', expected: '[object Object]' },
-    ])('in $locale', ({ locale, expected }) => {
+    test.each((['zh', 'zh-hans', 'zh-hant', 'zh-cn', 'zh-sg', 'zh-my', 'zh-mo', 'zh-hk', 'zh-tw'] as const).map(function (locale) {
+      return {locale, expected: String(CANDIDATES[locale])};
+    }))('in $locale', ({ locale, expected }) => {
       getter.mockReturnValue(locale);
 
       /// @ts-expect-error For testing

--- a/tests/HanAssist.localize.test.ts
+++ b/tests/HanAssist.localize.test.ts
@@ -1,5 +1,6 @@
 import HanAssist from '../lib/HanAssist';
 import { getter } from './mediawiki-mock';
+import { langNCandidatesKeyNameMap } from './utils';
 
 describe('HanAssist.localize', () => {
   afterEach(() => {
@@ -106,9 +107,7 @@ describe('HanAssist.localize', () => {
       sg: BigInt(123),
     };
 
-    test.each((['zh', 'zh-hans', 'zh-hant', 'zh-cn', 'zh-sg', 'zh-my', 'zh-mo', 'zh-hk', 'zh-tw'] as const).map(function (locale) {
-      return {locale, expected: String(CANDIDATES[locale])};
-    }))('in $locale', ({ locale, expected }) => {
+    test.each((langNCandidatesKeyNameMap).map(([locale, key]) => ({ locale, expected: String(CANDIDATES[key]) })))('in $locale', ({ locale, expected }) => {
       getter.mockReturnValue(locale);
 
       /// @ts-expect-error For testing

--- a/tests/HanAssist.vary.test.ts
+++ b/tests/HanAssist.vary.test.ts
@@ -160,17 +160,9 @@ describe('HanAssist.vary', () => {
       sg: BigInt(123),
     };
 
-    test.each([
-      { locale: 'zh', expected: '123' },
-      { locale: 'zh-hans', expected: 'Symbol()' },
-      { locale: 'zh-hant', expected: 'function () { }' },
-      { locale: 'zh-cn', expected: '123' },
-      { locale: 'zh-sg', expected: '123' },
-      { locale: 'zh-my', expected: 'true' },
-      { locale: 'zh-mo', expected: '[object Object]' },
-      { locale: 'zh-hk', expected: 'function Function() { [native code] }' },
-      { locale: 'zh-tw', expected: '[object Object]' },
-    ])('in $locale', ({ locale, expected }) => {
+    test.each((['zh', 'zh-hans', 'zh-hant', 'zh-cn', 'zh-sg', 'zh-my', 'zh-mo', 'zh-hk', 'zh-tw'] as const).map(function (locale) {
+      return {locale, expected: String(CANDIDATES[locale])};
+    }))('in $locale', ({ locale, expected }) => {
       getter.mockImplementation((val) => {
         if (val === 'wgUserVariant') {
           return locale;

--- a/tests/HanAssist.vary.test.ts
+++ b/tests/HanAssist.vary.test.ts
@@ -1,5 +1,6 @@
 import HanAssist from '../lib/HanAssist';
 import { getter } from './mediawiki-mock';
+import { langNCandidatesKeyNameMap } from './utils';
 
 describe('HanAssist.vary', () => {
   afterEach(() => {
@@ -160,9 +161,7 @@ describe('HanAssist.vary', () => {
       sg: BigInt(123),
     };
 
-    test.each((['zh', 'zh-hans', 'zh-hant', 'zh-cn', 'zh-sg', 'zh-my', 'zh-mo', 'zh-hk', 'zh-tw'] as const).map(function (locale) {
-      return {locale, expected: String(CANDIDATES[locale])};
-    }))('in $locale', ({ locale, expected }) => {
+    test.each((langNCandidatesKeyNameMap).map(([locale, key]) => ({ locale, expected: String(CANDIDATES[key]) })))('in $locale', ({ locale, expected }) => {
       getter.mockImplementation((val) => {
         if (val === 'wgUserVariant') {
           return locale;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const langNCandidatesKeyNameMap = [
+  ['zh', 'zh'], ['zh-hans', 'hans'], ['zh-hant', 'hant'], ['zh-cn', 'cn'],
+  ['zh-sg', 'sg'], ['zh-my', 'my'], ['zh-mo', 'mo'], ['zh-hk', 'hk'], ['zh-tw', 'tw'],
+] as const;


### PR DESCRIPTION
Safey toString test is broken when using special backends or changing the typescript compiler target to es6 or higher, so it's better to rely on more trusted values.